### PR TITLE
43 add message

### DIFF
--- a/auth_api/services/handlers/exception_handlers.py
+++ b/auth_api/services/handlers/exception_handlers.py
@@ -95,8 +95,7 @@ class ExceptionHandler:
                     e.msg = "; ".join([error for error in e.detail])
                 return Response(
                     data={
-                        "successMessage": None,
-                        "errorMessage": (
+                        "message": (
                             f"{handler['message']}: {e.msg}"
                             if hasattr(e, "msg")
                             else f"{handler['message']}: {str(e)}"

--- a/auth_api/tests/handlers/test_exception_handlers.py
+++ b/auth_api/tests/handlers/test_exception_handlers.py
@@ -18,7 +18,7 @@ class TestExceptionHandler:
         exception = UserNotFoundError("User not found")
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["errorMessage"] == "UserNotFoundError: User not found"
+        assert response.data["message"] == "UserNotFoundError: User not found"
 
     def test_handle_exception_user_already_verified(self):
         handler = ExceptionHandler()
@@ -26,7 +26,7 @@ class TestExceptionHandler:
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserAlreadyVerifiedError: User already verified"
         )
 
@@ -35,23 +35,21 @@ class TestExceptionHandler:
         exception = UserNotVerifiedError("User not verified")
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert (
-            response.data["errorMessage"] == "UserNotVerifiedError: User not verified"
-        )
+        assert response.data["message"] == "UserNotVerifiedError: User not verified"
 
     def test_handle_exception_email_not_sent(self):
         handler = ExceptionHandler()
         exception = EmailNotSentError("Email not sent")
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert response.data["errorMessage"] == "EmailNotSentError: Email not sent"
+        assert response.data["message"] == "EmailNotSentError: Email not sent"
 
     def test_handle_exception_otp_not_verified(self):
         handler = ExceptionHandler()
         exception = OTPNotVerifiedError("OTP not verified")
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["errorMessage"] == "OTPNotVerifiedError: OTP not verified"
+        assert response.data["message"] == "OTPNotVerifiedError: OTP not verified"
 
     def test_handle_exception_user_authentication_failed(self):
         handler = ExceptionHandler()
@@ -59,7 +57,7 @@ class TestExceptionHandler:
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserAuthenticationFailedError: Password is invalid"
         )
 
@@ -69,6 +67,6 @@ class TestExceptionHandler:
         response = handler.handle_exception(exception)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotAuthenticatedError: User not authenticated"
         )

--- a/auth_api/tests/views/test_all_users.py
+++ b/auth_api/tests/views/test_all_users.py
@@ -16,9 +16,8 @@ class TestAllUsersView:
         response_data = response.data
 
         assert "data" in response_data
-        assert "successMessage" in response_data
-        assert "errorMessage" in response_data
-        assert not response_data["errorMessage"]
+        assert "message" in response_data
+        assert not response_data["message"]
         assert isinstance(response_data["data"], dict)
 
         assert "user_list" in response_data["data"]

--- a/auth_api/tests/views/test_create_users.py
+++ b/auth_api/tests/views/test_create_users.py
@@ -20,8 +20,7 @@ class TestCreateUsersView:
         response = client.post(self.url, data, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data["successMessage"] == DEFAULT_VERIFICATION_MESSAGE
-        assert response.data["errorMessage"] is None
+        assert response.data["message"] == DEFAULT_VERIFICATION_MESSAGE
 
         user = User.objects.get(email="testuser@example.com")
         assert user.fname == "Test"
@@ -33,8 +32,7 @@ class TestCreateUsersView:
         response = client.post(self.url, data, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["successMessage"] is None
-        assert "errorMessage" in response.data
+        assert "message" in response.data
 
     def test_create_user_missing_email_fields(self):
         client = APIClient()
@@ -42,8 +40,7 @@ class TestCreateUsersView:
         response = client.post(self.url, data, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["successMessage"] is None
-        assert "errorMessage" in response.data
+        assert "message" in response.data
 
     def test_create_user_missing_password_fields(self):
         client = APIClient()
@@ -51,8 +48,7 @@ class TestCreateUsersView:
         response = client.post(self.url, data, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["successMessage"] is None
-        assert "errorMessage" in response.data
+        assert "message" in response.data
 
     def test_create_user_invalid_email(self):
         client = APIClient()
@@ -68,8 +64,7 @@ class TestCreateUsersView:
         response = client.post(self.url, data, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["successMessage"] is None
-        assert "errorMessage" in response.data
+        assert "message" in response.data
 
     def test_create_user_duplicate_email(self):
         client = APIClient()
@@ -89,5 +84,4 @@ class TestCreateUsersView:
         )  # Attempt to create a duplicate user
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["successMessage"] is None
-        assert "errorMessage" in response.data
+        assert "message" in response.data

--- a/auth_api/tests/views/test_remove_user.py
+++ b/auth_api/tests/views/test_remove_user.py
@@ -18,8 +18,7 @@ class TestRemoveUserView:
         response = api_client.post(self.url, data, headers=headers, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["successMessage"] == "User removed Successfully."
-        assert response.data["errorMessage"] is None
+        assert response.data["message"] == "User removed Successfully."
 
         with pytest.raises(User.DoesNotExist):
             User.objects.get(email="koushikmallik001@gmail.com")
@@ -34,10 +33,9 @@ class TestRemoveUserView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotFoundError: This user is not registered. Please register as new user."
         )
-        assert response.data["successMessage"] is None
 
     def test_remove_user_missing_email(self, api_client: APIClient, access_token: str):
         data = {}
@@ -48,8 +46,7 @@ class TestRemoveUserView:
         response = api_client.post(self.url, data, headers=headers, format="json")
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        assert response.data["errorMessage"] == "ValueError: Email is required."
-        assert response.data["successMessage"] is None
+        assert response.data["message"] == "ValueError: Email is required."
 
     def test_remove_user_unauthorized(self, api_client: APIClient):
         data = {"email": "koushikmallik001@gmail.com"}
@@ -60,7 +57,6 @@ class TestRemoveUserView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotAuthenticatedError: The user is not authenticated, please re-login."
         )
-        assert response.data["successMessage"] is None

--- a/auth_api/tests/views/test_reset_password.py
+++ b/auth_api/tests/views/test_reset_password.py
@@ -13,10 +13,7 @@ class TestPasswordResetView:
         response = api_client.post(self.url, data, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert (
-            response.data["successMessage"] == "Password reset email sent successfully."
-        )
-        assert response.data["errorMessage"] is None
+        assert response.data["message"] == "Password reset email sent successfully."
 
     def test_password_reset_user_not_found(self, api_client: APIClient):
         data = {"email": "nonexistentuser@example.com"}
@@ -24,10 +21,9 @@ class TestPasswordResetView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotFoundError: This user is not registered. Please register as new user."
         )
-        assert response.data["successMessage"] is None
 
     def test_password_reset_missing_email(self, api_client: APIClient):
         data = {}
@@ -35,7 +31,6 @@ class TestPasswordResetView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotFoundError: This user is not registered. Please register as new user."
         )
-        assert response.data["successMessage"] is None

--- a/auth_api/tests/views/test_send_otp.py
+++ b/auth_api/tests/views/test_send_otp.py
@@ -21,10 +21,9 @@ class TestSendOTPView:
 
             assert response.status_code == status.HTTP_200_OK
             assert (
-                response.data["successMessage"]
+                response.data["message"]
                 == "Verification Email has been sent successfully to the user. Please verify your email to access the account."
             )
-            assert response.data["errorMessage"] is None
 
     def test_send_otp_user_already_verified(self):
         User.objects.create(email="testuser@example.com", is_active=True)
@@ -35,10 +34,9 @@ class TestSendOTPView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserAlreadyVerifiedError: This user is already verified."
         )
-        assert response.data["successMessage"] is None
 
     def test_send_otp_email_not_sent(self):
         User.objects.create(email="testuser@example.com", is_active=False)
@@ -50,10 +48,9 @@ class TestSendOTPView:
 
             assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
             assert (
-                response.data["errorMessage"]
+                response.data["message"]
                 == "EmailNotSentError: Verification Email could not be sent."
             )
-            assert response.data["successMessage"] is None
 
     def test_send_otp_user_not_found(self):
         client = APIClient()
@@ -62,10 +59,9 @@ class TestSendOTPView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotFoundError: This user is not registered. Please register as new user."
         )
-        assert response.data["successMessage"] is None
 
     def test_send_otp_value_error(self):
         client = APIClient()
@@ -74,7 +70,6 @@ class TestSendOTPView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotFoundError: This user is not registered. Please register as new user."
         )
-        assert response.data["successMessage"] is None

--- a/auth_api/tests/views/test_sign_in.py
+++ b/auth_api/tests/views/test_sign_in.py
@@ -49,5 +49,5 @@ class TestSignInView:
             assert response.get("token")
             assert isinstance(response.get("token"), dict)
         else:
-            assert response.get("errorMessage")
-            assert response.get("errorMessage") == expected
+            assert response.get("message")
+            assert response.get("message") == expected

--- a/auth_api/tests/views/test_update_password.py
+++ b/auth_api/tests/views/test_update_password.py
@@ -20,8 +20,7 @@ class TestUpdatePasswordView:
         response = api_client.post(self.url, data, headers=headers, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["successMessage"] == "Password updated successfully."
-        assert response.data["errorMessage"] is None
+        assert response.data["message"] == "Password updated successfully."
 
     def test_update_password_unauthorized(self, api_client: APIClient):
         data = {
@@ -32,10 +31,9 @@ class TestUpdatePasswordView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotAuthenticatedError: The user is not authenticated, please re-login."
         )
-        assert response.data["successMessage"] is None
 
     @pytest.mark.usefixtures("create_test_user")
     def test_update_password_not_matching(
@@ -53,10 +51,9 @@ class TestUpdatePasswordView:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "PasswordNotMatchError: Passwords are not matching or not in correct format."
         )
-        assert response.data["successMessage"] is None
 
     @pytest.mark.usefixtures("create_test_user")
     def test_update_password_invalid_data(
@@ -73,7 +70,5 @@ class TestUpdatePasswordView:
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert (
-            response.data["errorMessage"]
-            == "ValueError: Please provide both the passwords."
+            response.data["message"] == "ValueError: Please provide both the passwords."
         )
-        assert response.data["successMessage"] is None

--- a/auth_api/tests/views/test_update_profile.py
+++ b/auth_api/tests/views/test_update_profile.py
@@ -27,8 +27,7 @@ class TestUpdateProfileView:
         response = api_client.post(self.url, data, headers=headers, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["successMessage"] == "User details updated Successfully."
-        assert response.data["errorMessage"] is None
+        assert response.data["message"] == "User details updated Successfully."
 
         user = User.objects.get(email="koushikmallik001@gmail.com")
         assert user.fname == "NewFirstName"
@@ -44,10 +43,9 @@ class TestUpdateProfileView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotAuthenticatedError: The user is not authenticated, please re-login."
         )
-        assert response.data["successMessage"] is None
 
     @pytest.mark.usefixtures("create_test_user")
     def test_update_profile_invalid_data(
@@ -65,7 +63,6 @@ class TestUpdateProfileView:
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "ValueError: First name is not in correct format."
         )
-        assert response.data["successMessage"] is None

--- a/auth_api/tests/views/test_user_details.py
+++ b/auth_api/tests/views/test_user_details.py
@@ -18,7 +18,7 @@ class TestUserDetailsView:
         response = api_client.get(self.url, headers=headers)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["successMessage"] == "User details fetched successfully."
+        assert response.data["message"] == "User details fetched successfully."
 
         assert response.data["data"]["email"]
         assert isinstance(response.data["data"]["email"], str)
@@ -52,10 +52,7 @@ class TestUserDetailsView:
         response = api_client.get(self.url, headers=headers)
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
-        assert (
-            response.data["errorMessage"] == "TokenError: Token is invalid or expired"
-        )
-        assert response.data["successMessage"] is None
+        assert response.data["message"] == "TokenError: Token is invalid or expired"
 
     def test_user_details_unauthorized(self, api_client: APIClient):
         headers = {
@@ -65,7 +62,6 @@ class TestUserDetailsView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert (
-            response.data["errorMessage"]
+            response.data["message"]
             == "UserNotAuthenticatedError: The user is not authenticated, please re-login."
         )
-        assert response.data["successMessage"] is None

--- a/auth_api/tests/views/test_verify_otp.py
+++ b/auth_api/tests/views/test_verify_otp.py
@@ -24,7 +24,7 @@ class TestVerifyOTPView:
             assert isinstance(response.data["token"], dict)
             assert response.data["token"]["access"]
             assert isinstance(response.data["token"]["access"], str)
-            assert response.data["errorMessage"] is None
+            assert response.data["message"] is None
 
     def test_verify_otp_failure_with_invalid_email(self, api_client: APIClient):
         with patch.object(OTPServices, "verify_otp", return_value=False):
@@ -33,7 +33,7 @@ class TestVerifyOTPView:
 
             assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert (
-                response.data["errorMessage"]
+                response.data["message"]
                 == "UserNotFoundError: This user is not registered. Please register as new user."
             )
 
@@ -44,7 +44,4 @@ class TestVerifyOTPView:
             response = api_client.post(self.url, data, format="json")
 
             assert response.status_code == status.HTTP_400_BAD_REQUEST
-            assert (
-                response.data["errorMessage"]
-                == "OTPNotVerifiedError: OTP did not match."
-            )
+            assert response.data["message"] == "OTPNotVerifiedError: OTP did not match."

--- a/auth_api/views/all_users.py
+++ b/auth_api/views/all_users.py
@@ -18,8 +18,7 @@ class AllUsersView(APIView):
                 return Response(
                     data={
                         "data": all_user_details.model_dump(),
-                        "successMessage": None,
-                        "errorMessage": None,
+                        "message": None,
                     },
                     status=status.HTTP_200_OK,
                     content_type="application/json",
@@ -28,8 +27,7 @@ class AllUsersView(APIView):
                 return Response(
                     data={
                         "data": {"user_list": []},
-                        "successMessage": "No User found in database.",
-                        "errorMessage": None,
+                        "message": "No User found in database.",
                     },
                     status=status.HTTP_200_OK,
                     content_type="application/json",

--- a/auth_api/views/create_user.py
+++ b/auth_api/views/create_user.py
@@ -19,8 +19,7 @@ class CreateUsersView(APIView):
             if result.get("successMessage"):
                 return Response(
                     data={
-                        "successMessage": result.get("successMessage"),
-                        "errorMessage": None,
+                        "message": result.get("successMessage"),
                     },
                     status=status.HTTP_201_CREATED,
                     content_type="application/json",

--- a/auth_api/views/otp_view.py
+++ b/auth_api/views/otp_view.py
@@ -30,8 +30,7 @@ class SendOTPView(APIView):
                     if response == "OK":
                         return Response(
                             data={
-                                "successMessage": DEFAULT_VERIFICATION_MESSAGE,
-                                "errorMessage": None,
+                                "message": DEFAULT_VERIFICATION_MESSAGE,
                             },
                             status=status.HTTP_200_OK,
                             content_type="application/json",

--- a/auth_api/views/password_reset.py
+++ b/auth_api/views/password_reset.py
@@ -20,8 +20,7 @@ class PasswordResetView(APIView):
                 result = UserServices().reset_password(email=email)
                 return Response(
                     data={
-                        "successMessage": result.get("successMessage"),
-                        "errorMessage": None,
+                        "message": result.get("successMessage"),
                     },
                     status=status.HTTP_200_OK,
                     content_type="application/json",

--- a/auth_api/views/remove_user.py
+++ b/auth_api/views/remove_user.py
@@ -30,8 +30,7 @@ class RemoveUserView(APIView):
                     User.objects.get(email=email).delete()
                     return Response(
                         data={
-                            "successMessage": "User removed Successfully.",
-                            "errorMessage": None,
+                            "message": "User removed Successfully.",
                         },
                         status=status.HTTP_200_OK,
                         content_type="application/json",

--- a/auth_api/views/sign_in.py
+++ b/auth_api/views/sign_in.py
@@ -23,7 +23,7 @@ class SignInView(APIView):
                 )
                 if result.get("token"):
                     return Response(
-                        data={"token": result.get("token"), "errorMessage": None},
+                        data={"token": result.get("token"), "message": None},
                         status=status.HTTP_200_OK,
                         content_type="application/json",
                     )

--- a/auth_api/views/update_password.py
+++ b/auth_api/views/update_password.py
@@ -23,8 +23,7 @@ class UpdatePasswordView(APIView):
                 )
                 return Response(
                     data={
-                        "successMessage": "Password updated successfully.",
-                        "errorMessage": None,
+                        "message": "Password updated successfully.",
                     },
                     status=status.HTTP_200_OK,
                     content_type="application/json",

--- a/auth_api/views/update_profile.py
+++ b/auth_api/views/update_profile.py
@@ -25,8 +25,7 @@ class UpdateProfileView(APIView):
                 )
                 return Response(
                     data={
-                        "successMessage": "User details updated Successfully.",
-                        "errorMessage": None,
+                        "message": "User details updated Successfully.",
                     },
                     status=status.HTTP_200_OK,
                     content_type="application/json",

--- a/auth_api/views/user_details.py
+++ b/auth_api/views/user_details.py
@@ -18,9 +18,8 @@ class UserDetailView(APIView):
                 user_details = UserServices().get_user_details(uid=user_id)
                 return Response(
                     data={
-                        "successMessage": "User details fetched successfully.",
+                        "message": "User details fetched successfully.",
                         "data": user_details.model_dump(),
-                        "errorMessage": None,
                     },
                     status=status.HTTP_200_OK,
                     content_type="application/json",

--- a/auth_api/views/validate_otp_view.py
+++ b/auth_api/views/validate_otp_view.py
@@ -19,7 +19,7 @@ class ValidateOTPView(APIView):
             return Response(
                 data={
                     "token": token,
-                    "errorMessage": None,
+                    "message": None,
                 },
                 status=status.HTTP_200_OK,
                 content_type="application/json",


### PR DESCRIPTION
### Overview

> Github Issue:[ #43 ](https://github.com/KoushikMallik-developer/split-it-api-v2/issues/43)

**What was the problem:**
We needed `message` in place of `errorMessage` or `successMessage`.

**How was this solved:**
We have added `message` in place of `errorMessage` or `successMessage`.

**Features:**
- will add `message` in response
-

**Services to be impacted:**
- `split-it-api-v2`

**Example Code or Screenshot:**
```
Example Code or Screenshot
```
![image](https://github.com/user-attachments/assets/e2116397-94c7-4818-9cfd-e9ce0a67c8f8)


**_For the PR Creator_**

- [x] Filled out entirely of PR Template.
- [x] Changes meet acceptance criteria defined in ticket.
- [x] Unit Tests Passed. :tada:
- [x] Tested on DEV Env.
- [ ] Tested on QA Env.
